### PR TITLE
feat(FlyingCards): :sparkles: Cores de swimlane dinâmicas

### DIFF
--- a/api/v2/src/modules/kanban/entities/swimlane.entity.ts
+++ b/api/v2/src/modules/kanban/entities/swimlane.entity.ts
@@ -21,7 +21,7 @@ export class Swimlane {
   @Column({ type: 'tinyint', width: 1, name: 'SWI_VERTICAL', default: 0 })
   vertical: boolean;
 
-  @Column({ type: 'varchar', name: 'SWI_COR', length: 6 })
+  @Column({ type: 'varchar', name: 'SWI_COR', length: 7, default: '#6d28d9' })
   cor: string;
 
   @CreateDateColumn({ name: 'SWI_CRIADO_EM' })

--- a/web/src/app/dashboard/pages/flyingcards-kanban/flyingcards-kanban.component.html
+++ b/web/src/app/dashboard/pages/flyingcards-kanban/flyingcards-kanban.component.html
@@ -25,8 +25,8 @@
   <div class="flex flex-grow overflow-x-auto" cdkDropListGroup>
     @if (board.swimlanes.length > 0) {
     <div
-      class="flex flex-col flex-grow min-w-fit min-h-fit my-10 mx-2 p-5 bg-violet-700 border-r-4 rounded-sm"
-      [ngStyle]="{ color: swimlane.cor }"
+      [style.--minha-cor]="swimlane.cor"
+      class="flex flex-col flex-grow min-w-fit min-h-fit my-10 mx-2 p-5 bg-[var(--minha-cor)] border-r-4 rounded-sm"
       *ngFor="let swimlane of board.swimlanes"
     >
       <div class="flex text-lg font-bold uppercase mb-5 justify-between">

--- a/web/src/app/dashboard/pages/flyingcards-swimlane-form/flyingcards-swimlane-form.component.html
+++ b/web/src/app/dashboard/pages/flyingcards-swimlane-form/flyingcards-swimlane-form.component.html
@@ -53,9 +53,10 @@
       <div class="relative w-full">
         <label for="cor" class="leading-7 text-sm text-gray-600">Cor</label>
         <input
-          type="text"
+          type="color"
           id="cor"
           name="cor"
+          value="#6d28d9"
           formControlName="cor"
           class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-violet-700 focus:bg-white focus:ring-2 focus:ring-violet-700 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out"
         />

--- a/web/src/app/dashboard/pages/flyingcards-swimlane-form/flyingcards-swimlane-form.component.ts
+++ b/web/src/app/dashboard/pages/flyingcards-swimlane-form/flyingcards-swimlane-form.component.ts
@@ -68,7 +68,7 @@ export class FlyingcardsSwimlaneFormComponent {
         Validators.required
       ),
       cor: new FormControl<string>(
-        this.swimlane.cor || '',
+        this.swimlane.cor || '#6d28d9',
         Validators.required
       ),
     });


### PR DESCRIPTION
O usuário pode escolher a cor da swimlane de forma dinâmica e refletir no banco de dados. Além disso, foi preciso mudar o banco para ter 7 caracteres na cor da swimlane e ainda não foi criada a migration nova para atualizar o banco.

O valor padrão da cor é roxo (#6d28d9).